### PR TITLE
Fixed type-hints

### DIFF
--- a/src/Crontab.php
+++ b/src/Crontab.php
@@ -47,11 +47,11 @@ class Crontab
 
     /**
      * Crontab constructor.
-     * @param $rule
-     * @param $callback
-     * @param null $name
+     * @param string $rule
+     * @param callable $callback
+     * @param string $name
      */
-    public function __construct($rule, $callback, $name = null)
+    public function __construct($rule, $callback, $name = '')
     {
         $this->_rule = $rule;
         $this->_callback = $callback;


### PR DESCRIPTION
The type-hints in the constructor do not match the respective properties they are assigned to. This causes static analyzers to raise annoying errors.